### PR TITLE
bugfix(github-pages): fix broken links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,12 @@ import NotePage from "./routes/NotePage";
 
 const router = createBrowserRouter([
   {
-    path: "/",
+    path: `${import.meta.env.BASE_URL}`,
     element: <Root />,
     errorElement: <ErrorPage />,
   },
   {
-    path: "/note/:id",
+    path: `${import.meta.env.BASE_URL}note/:id/`,
     element: <NotePage />,
     errorElement: <ErrorPage />,
   },

--- a/src/components/CreateNote.tsx
+++ b/src/components/CreateNote.tsx
@@ -35,7 +35,7 @@ export default (props: IProps) => {
       body: "",
     };
     dispatch(add(note));
-    navigate("/note/" + note.id);
+    navigate(`${import.meta.env.BASE_URL}note/${note.id}`);
   };
 
   return (

--- a/src/components/Explorer.tsx
+++ b/src/components/Explorer.tsx
@@ -25,7 +25,7 @@ export default () => {
         </div>
         <div flex="~ col" space="y-2px">
           {notes.map((note) => (
-            <Link hover="op70" key={note.id} to={`/note/${note.id}`}>
+            <Link hover="op70" key={note.id} to={`${import.meta.env.BASE_URL}note/${note.id}/`}>
               {note.title}
             </Link>
           ))}

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -23,7 +23,7 @@ export default ({ note, updateNote }: IProps) => {
           handleChange={(title) => updateNote({ ...note, title })}
           class="b-none text-26px font-bold w-full focus:outline-none mb-1rem"
         />
-        <Link to="/" bg="main-red" p="4px" m="auto" rounded="full">
+        <Link to={`${import.meta.env.BASE_URL}`} bg="main-red" p="4px" m="auto" rounded="full">
           <div className="i-akar-icons:arrow-back" m="5px" bg="white"></div>
         </Link>
       </div>

--- a/src/routes/ErrorPage.tsx
+++ b/src/routes/ErrorPage.tsx
@@ -30,7 +30,7 @@ export default (props: IErrorPage) => {
       <p mt="6px">
         <i>{message}</i>
       </p>
-      <Link to="/">
+      <Link to={`${import.meta.env.BASE_URL}`}>
         <button btn="main" p="y-.4rem x-1rem" m="t-2rem">
           home
         </button>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "types": ["vite/client"]
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
Some link weren't working properly in GitHub pages because they weren't using the enviroment variable `BASE_URL`.