### PR TITLE
fix(notes): align go back button with title

### DIFF
--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -22,7 +22,7 @@ export default function Note({ note, updateNote }: IProps) {
         "overflow-y-auto",
       )}
     >
-      <div className={classNames("flex", "flex-row")}>
+      <div className="flex mb-1rem">
         <Editable
           content={note.title}
           handleChange={(title) => updateNote({ ...note, title })}
@@ -36,28 +36,32 @@ export default function Note({ note, updateNote }: IProps) {
             "text-26px",
             "font-bold",
             "w-full",
-            "focus:outline-none",
-            "mb-1rem",
+            "focus:outline-none"
           )}
         />
+
         <Link
           to={`${import.meta.env.BASE_URL}`}
           className={classNames(
+            "inline-flex",
+            "items-center",
+            "justify-center",
             "bg-main-red",
             "p-4px",
             "m-auto",
             "rounded-full",
           )}
         >
-          <div
+          <i
             className={classNames(
               "i-akar-icons:arrow-back",
               "m-5px",
-              "bg-white",
+              "color-white",
             )}
-          ></div>
+          />
         </Link>
       </div>
+
       <Editable
         content={note.body}
         handleChange={(body) => updateNote({ ...note, body })}

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -36,7 +36,7 @@ export default function Note({ note, updateNote }: IProps) {
             "text-26px",
             "font-bold",
             "w-full",
-            "focus:outline-none"
+            "focus:outline-none",
           )}
         />
 

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -43,7 +43,7 @@ export default function Note({ note, updateNote }: IProps) {
         <Link
           to={`${import.meta.env.BASE_URL}`}
           className={classNames(
-            "inline-flex",
+            "flex",
             "items-center",
             "justify-center",
             "bg-main-red",


### PR DESCRIPTION
Aligned go back button with the note title.

## Before

![image](https://github.com/msga-mmm/chained-notes-web/assets/109926431/551d31b2-637a-47a8-9218-65f5aa456f98)

## After

![image](https://github.com/msga-mmm/chained-notes-web/assets/109926431/16b0d85c-1513-458a-a0e3-5adc011dc6a7)