### PR TITLE
fix: avoid infinite loop in useEffect injecting axios token

### DIFF
--- a/src/components/Explorer/Explorer.test.tsx
+++ b/src/components/Explorer/Explorer.test.tsx
@@ -1,6 +1,5 @@
 // TODO: avoid disabling eslint rule
 /* eslint-disable functional/no-expression-statements */
-/* eslint-disable @typescript-eslint/no-floating-promises */
 
 import Explorer from "./Explorer";
 

--- a/src/components/NoteEditor/NoteEditor.test.tsx
+++ b/src/components/NoteEditor/NoteEditor.test.tsx
@@ -1,6 +1,5 @@
 // TODO: avoid disabling eslint rule
 /* eslint-disable functional/no-expression-statements */
-/* eslint-disable @typescript-eslint/no-floating-promises */
 
 import NoteEditor from "./NoteEditor";
 

--- a/src/hooks/use-inject-token-to-axios-instance.ts
+++ b/src/hooks/use-inject-token-to-axios-instance.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from "axios";
 import { ReadonlyDeep } from "type-fest";
@@ -21,7 +21,7 @@ export function useInjectTokenToAxiosInstance({
   getToken,
   onUnauthorized,
 }: ReadonlyDeep<UseInjectTokenToAxiosInstanceParams>) {
-  const [axiosInterceptor, setAxiosInterceptor] = useState<number>();
+  const axiosInterceptor = useRef<number>();
 
   const handleFulfilled = useCallback(
     // TODO: avoid disabling the rule functional/prefer-immutable-types, it is
@@ -58,8 +58,8 @@ export function useInjectTokenToAxiosInstance({
     // clear previous interceptor to avoid having more than one interceptor to
     // inject the bearer token
     // eslint-disable-next-line functional/no-conditional-statements
-    if (axiosInterceptor !== undefined) {
-      axiosInstance.interceptors.request.eject(axiosInterceptor);
+    if (axiosInterceptor.current !== undefined) {
+      axiosInstance.interceptors.request.eject(axiosInterceptor.current);
     }
 
     const interceptor = axiosInstance.interceptors.request.use(
@@ -67,12 +67,6 @@ export function useInjectTokenToAxiosInstance({
       handleRejected,
     );
 
-    setAxiosInterceptor(interceptor);
-  }, [
-    axiosInstance,
-    handleFulfilled,
-    handleRejected,
-    axiosInterceptor,
-    setAxiosInterceptor,
-  ]);
+    axiosInterceptor.current = interceptor;
+  }, [axiosInstance, handleFulfilled, handleRejected, axiosInterceptor]);
 }

--- a/src/hooks/use-inject-token-to-axios-instance.ts
+++ b/src/hooks/use-inject-token-to-axios-instance.ts
@@ -70,5 +70,5 @@ export function useInjectTokenToAxiosInstance({
     // TODO: avoid mutating objects, it could lead to side-effects
     // eslint-disable-next-line functional/immutable-data, functional/no-expression-statements
     axiosInterceptor.current = interceptor;
-  }, [axiosInstance, handleFulfilled, handleRejected, axiosInterceptor]);
+  }, [axiosInstance, handleFulfilled, handleRejected]);
 }

--- a/src/hooks/use-inject-token-to-axios-instance.ts
+++ b/src/hooks/use-inject-token-to-axios-instance.ts
@@ -67,6 +67,8 @@ export function useInjectTokenToAxiosInstance({
       handleRejected,
     );
 
+    // TODO: avoid mutating objects, it could lead to side-effects
+    // eslint-disable-next-line functional/immutable-data, functional/no-expression-statements
     axiosInterceptor.current = interceptor;
   }, [axiosInstance, handleFulfilled, handleRejected, axiosInterceptor]);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced promise handling in tests for `Explorer` and `NoteEditor` components.
  
- **Refactor**
	- Improved efficiency of the token injection hook by simplifying state management and cleanup processes. 

These changes contribute to a more robust testing environment and streamline API interactions within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->