### PR TITLE
fix: add match rule to renovate to have valid format

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,18 @@
   "extends": ["config:recommended"],
   "packageRules": [
     {
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "lockFileMaintenance",
+        "rollback",
+        "bump",
+        "replacement"
+      ],
       "automerge": true
     }
   ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Renovate bot configuration to provide more granular control over automatic update matching and merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->